### PR TITLE
Fix typo.

### DIFF
--- a/hastratum1.logrotate
+++ b/hastratum1.logrotate
@@ -3,5 +3,5 @@
     rotate 5
     compress
     delaycompress
-    dataext
+    dateext
 }


### PR DESCRIPTION
Logrotation option dataext does not exit. Most probably it meant to be dateext.